### PR TITLE
sets opacity before rendering text

### DIFF
--- a/src/nodeparser.js
+++ b/src/nodeparser.js
@@ -444,6 +444,7 @@ NodeParser.prototype.paintText = function(container) {
     var shadows = container.parent.parseTextShadows();
 
     this.renderer.font(container.parent.color('color'), container.parent.css('fontStyle'), container.parent.css('fontVariant'), weight, size, family);
+    this.renderer.setOpacity(container.parent.opacity);
     if (shadows.length) {
         // TODO: support multiple text shadows
         this.renderer.fontShadow(shadows[0].color, shadows[0].offsetX, shadows[0].offsetY, shadows[0].blur);


### PR DESCRIPTION
If the previous element rendered element set global opacity to 0 the text would not be rendered
